### PR TITLE
Add comprehensive debugging for quotation save/load issue

### DIFF
--- a/DEBUG_SALVAMENTO_COTACOES.md
+++ b/DEBUG_SALVAMENTO_COTACOES.md
@@ -1,0 +1,157 @@
+# Debug do Salvamento de Cotações
+
+## 🚨 Problema Identificado
+
+**Issue**: Valores dos itens aparecem zerados após salvar e recarregar cotação
+**Local**: Interface de cotações (salvamento/carregamento de itens)
+
+## 🔍 Debug Implementado
+
+### 1. **Debug no Salvamento**
+- Mostra valores originais da interface (TreeView)
+- Mostra valores após conversão com clean_number
+- Confirma o que foi inserido no banco
+
+### 2. **Debug no Carregamento**  
+- Mostra valores vindos diretamente do banco
+- Mostra valores após formatação para interface
+- Confirma o que é exibido na TreeView
+
+## 🧪 Como Testar
+
+### 1. **Executar Sistema**
+```bash
+python3 main.py
+```
+
+### 2. **Cenário de Teste**
+1. Fazer login
+2. Ir para "Cotações" → "Nova Cotação"
+3. Preencher dados básicos (número, cliente)
+4. **Adicionar item com valor**:
+   - Tipo: Produto
+   - Nome: Teste Debug
+   - Quantidade: 2
+   - Valor Unitário: 150.50
+5. **Salvar cotação**
+6. **Verificar console** para logs de salvamento
+7. **Recarregar cotação** (editar a mesma)
+8. **Verificar console** para logs de carregamento
+9. **Verificar interface** se valores aparecem corretos
+
+### 3. **Logs Esperados**
+
+#### Salvamento:
+```
+DEBUG SALVAMENTO - Item: Teste Debug
+  - Valores originais: ('Produto', 'Teste Debug', '2.00', 'R$ 150,50', 'R$ 0,00', 'R$ 0,00', 'R$ 0,00', 'R$ 301,00', '')
+  - Valor unit string: 'R$ 150,50'
+  - Total string: 'R$ 301,00'
+  - Valor unit convertido: 150.5
+  - Total convertido: 301.0
+  - Quantidade: 2.0
+  - Inserido no banco: cotacao_id=123, tipo=Produto, nome=Teste Debug
+  - Valores inseridos: unit=150.5, total=301.0
+  ---
+```
+
+#### Carregamento:
+```
+DEBUG CARREGAMENTO - Item: Teste Debug
+  - Row do banco: ('Produto', 'Teste Debug', 2.0, 150.5, 301.0, '', 0.0, 0.0, 0.0)
+  - Valor unit do banco: 150.5
+  - Total do banco: 301.0
+  - Valor unit formatado: R$ 150,50
+  - Total formatado: R$ 301,00
+  ---
+```
+
+## 🔧 Possíveis Problemas e Soluções
+
+### **Caso 1: Valores Zerados no Salvamento**
+```
+  - Valor unit convertido: 0.0
+  - Total convertido: 0.0
+```
+**Problema**: clean_number não está funcionando ou valores da interface estão incorretos
+**Solução**: Verificar função clean_number e format_currency
+
+### **Caso 2: Valores Corretos no Salvamento, Zerados no Carregamento**
+```
+Salvamento: Valores inseridos: unit=150.5, total=301.0
+Carregamento: Valor unit do banco: 0.0
+```
+**Problema**: Banco de dados não está salvando ou query está incorreta
+**Solução**: Verificar schema do banco e commits
+
+### **Caso 3: Valores Corretos no Carregamento, Zerados na Interface**
+```
+Carregamento: Total do banco: 301.0
+Interface: Mostra R$ 0,00
+```
+**Problema**: format_currency não está funcionando corretamente
+**Solução**: Verificar função format_currency
+
+### **Caso 4: Problema na Conversão de Moeda**
+```
+  - Valor unit string: 'R$ 150,50'
+  - Valor unit convertido: 0.0
+```
+**Problema**: clean_number não remove "R$ " ou não converte vírgula
+**Solução**: Melhorar função clean_number
+
+## 🛠️ Correções Baseadas no Debug
+
+### **Se clean_number estiver falhando**:
+```python
+def clean_number(value):
+    if not value:
+        return 0.0
+    try:
+        # Remove R$, espaços e converte vírgula para ponto
+        cleaned = str(value).replace('R$', '').replace(' ', '').replace(',', '.')
+        return float(cleaned)
+    except (ValueError, TypeError):
+        return 0.0
+```
+
+### **Se format_currency estiver falhando**:
+```python
+def format_currency(value):
+    if value is None:
+        return "R$ 0,00"
+    try:
+        return f"R$ {float(value):,.2f}".replace(',', 'X').replace('.', ',').replace('X', '.')
+    except (ValueError, TypeError):
+        return "R$ 0,00"
+```
+
+### **Se o problema for no TreeView**:
+Verificar se as colunas estão na ordem correta e se os índices correspondem.
+
+## 📋 Checklist de Verificação
+
+### Durante o Teste:
+- [ ] Valores aparecem corretos na interface antes de salvar
+- [ ] Logs de salvamento mostram valores corretos
+- [ ] Logs de carregamento mostram valores corretos
+- [ ] Interface mostra valores corretos após carregamento
+
+### Análise dos Logs:
+- [ ] clean_number funciona corretamente
+- [ ] Valores são salvos no banco corretamente
+- [ ] Valores são carregados do banco corretamente
+- [ ] format_currency formata corretamente
+
+## 🎯 Próximo Passo
+
+1. **Execute o teste** com o cenário descrito
+2. **Analise os logs** no console
+3. **Identifique onde o problema ocorre**:
+   - Salvamento (valores viram 0 na conversão)
+   - Banco (valores não são salvos)
+   - Carregamento (valores não são recuperados)
+   - Interface (valores não são exibidos)
+4. **Aplique a correção** específica conforme o problema identificado
+
+**Com esses logs detalhados, vamos identificar exatamente onde os valores estão sendo perdidos!** 🔍

--- a/interface/modules/cotacoes.py
+++ b/interface/modules/cotacoes.py
@@ -675,6 +675,12 @@ class CotacoesModule(BaseModule):
                 values = self.itens_tree.item(item)['values']
                 tipo, nome, qtd, valor_unit, mao_obra, desloc, estadia, total, desc = values
                 
+                # DEBUG: Mostrar valores originais
+                print(f"DEBUG SALVAMENTO - Item: {nome}")
+                print(f"  - Valores originais: {values}")
+                print(f"  - Valor unit string: '{valor_unit}'")
+                print(f"  - Total string: '{total}'")
+                
                 # Converter valores
                 quantidade = float(qtd)
                 valor_unitario = clean_number(valor_unit.replace('R$ ', ''))
@@ -683,6 +689,11 @@ class CotacoesModule(BaseModule):
                 valor_estadia = clean_number(estadia.replace('R$ ', ''))
                 valor_total_item = clean_number(total.replace('R$ ', ''))
                 
+                # DEBUG: Mostrar valores convertidos
+                print(f"  - Valor unit convertido: {valor_unitario}")
+                print(f"  - Total convertido: {valor_total_item}")
+                print(f"  - Quantidade: {quantidade}")
+                
                 c.execute("""
                     INSERT INTO itens_cotacao (cotacao_id, tipo, item_nome, quantidade,
                                              valor_unitario, valor_total_item, descricao,
@@ -690,6 +701,11 @@ class CotacoesModule(BaseModule):
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """, (cotacao_id, tipo, nome, quantidade, valor_unitario,
                      valor_total_item, desc, valor_mao_obra, valor_desloc, valor_estadia))
+                
+                # DEBUG: Verificar o que foi inserido
+                print(f"  - Inserido no banco: cotacao_id={cotacao_id}, tipo={tipo}, nome={nome}")
+                print(f"  - Valores inseridos: unit={valor_unitario}, total={valor_total_item}")
+                print("  ---")
             
             conn.commit()
             self.show_success("Cotação salva com sucesso!")
@@ -898,6 +914,16 @@ class CotacoesModule(BaseModule):
             
             for row in c.fetchall():
                 tipo, nome, qtd, valor_unit, total, desc, mao_obra, desloc, estadia = row
+                
+                # DEBUG: Mostrar valores carregados do banco
+                print(f"DEBUG CARREGAMENTO - Item: {nome}")
+                print(f"  - Row do banco: {row}")
+                print(f"  - Valor unit do banco: {valor_unit}")
+                print(f"  - Total do banco: {total}")
+                print(f"  - Valor unit formatado: {format_currency(valor_unit)}")
+                print(f"  - Total formatado: {format_currency(total)}")
+                print("  ---")
+                
                 self.itens_tree.insert("", "end", values=(
                     tipo,
                     nome,


### PR DESCRIPTION
Problem identified: Item values become zero after saving and reloading quotation

Debug added:
- Detailed logging in salvar_cotacao() function
  * Shows original TreeView values
  * Shows values after clean_number conversion
  * Confirms what gets inserted to database

- Detailed logging in carregar_itens_cotacao() function
  * Shows raw values from database
  * Shows values after format_currency formatting
  * Confirms what gets displayed in TreeView

Debug will identify exactly where values are lost:
- During save (conversion issue)
- In database (storage issue)
- During load (retrieval issue)
- In interface (display issue)

Next step: Run system, test save/reload scenario, analyze console logs to pinpoint exact location where values become zero