### PR TITLE
🔧 HOTFIX: Fixed format_phone import error in PDF generation

### DIFF
--- a/pdf_generators/cotacao_nova.py
+++ b/pdf_generators/cotacao_nova.py
@@ -427,7 +427,6 @@ def gerar_pdf_cotacao_nova(cotacao_id, db_name, current_user=None):
         pdf.set_font("Arial", '', 10)
         cliente_cnpj = getattr(pdf, 'cliente_cnpj', '')
         if cliente_cnpj:
-            from utils.formatters import format_cnpj
             cnpj_texto = f"CNPJ: {format_cnpj(cliente_cnpj)}"
         else:
             cnpj_texto = "CNPJ: N/A"
@@ -440,7 +439,6 @@ def gerar_pdf_cotacao_nova(cotacao_id, db_name, current_user=None):
         # Telefone
         cliente_telefone = getattr(pdf, 'cliente_telefone', '')
         if cliente_telefone:
-            from utils.formatters import format_phone
             telefone_texto = f"FONE: {format_phone(cliente_telefone)}"
         else:
             telefone_texto = "FONE: N/A"


### PR DESCRIPTION
ERROR RESOLVED: 'cannot access local variable format_phone where it is not associated with a value'

ROOT CAUSE:
- format_phone and format_cnpj functions were being imported inside conditional blocks
- This caused NameError when conditions weren't met
- Functions were already imported at top of file but duplicated imports were causing conflicts

SOLUTION:
✅ Removed duplicate imports from within conditional blocks:
   - Removed 'from utils.formatters import format_cnpj' from CNPJ section
   - Removed 'from utils.formatters import format_phone' from phone section ✅ Functions are already properly imported at file top ✅ All formatting functions now accessible throughout the function

IMPACT:
- PDF generation now works without import errors
- Maintains all formatting functionality
- No changes to PDF layout or content
- Quick fix for production readiness

TESTED: Functions format_phone, format_cnpj available from top-level imports

STATUS: ✅ PDF GENERATION ERROR RESOLVED